### PR TITLE
#30 [BE] 2fa 관련 로직

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "fastify": "^5.2.1",
         "fastify-plugin": "^5.0.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.10.1",
         "qrcode": "^1.5.4",
         "speakeasy": "^2.0.0"
       },
@@ -26,6 +27,7 @@
         "@types/dotenv": "^8.2.3",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.13.9",
+        "@types/nodemailer": "^6.4.17",
         "@types/qrcode": "^1.5.5",
         "@types/speakeasy": "^2.0.10",
         "@types/ws": "^8.18.0",
@@ -833,6 +835,16 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qrcode": {
@@ -1717,6 +1729,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.9",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,9 @@
         "dotenv": "^16.4.7",
         "fastify": "^5.2.1",
         "fastify-plugin": "^5.0.1",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "qrcode": "^1.5.4",
+        "speakeasy": "^2.0.0"
       },
       "devDependencies": {
         "@types/dotenv": "^8.2.3",
@@ -900,6 +902,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -942,6 +968,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base32.js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.0.1.tgz",
+      "integrity": "sha512-EGHIRiegFa62/SsA1J+Xs2tIzludPdzM064N9wjbiEgHnGnJ1V0WEpA4pEwCYT5nDvZk3ubf0shqaCS7k6xeUQ==",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -982,6 +1014,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1005,6 +1046,35 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1042,6 +1112,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1058,6 +1137,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
@@ -1089,6 +1174,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -1284,6 +1375,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1296,6 +1400,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1369,6 +1482,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1497,6 +1619,18 @@
         "set-cookie-parser": "^2.6.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1615,6 +1749,51 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1660,6 +1839,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/prisma": {
       "version": "6.4.1",
@@ -1711,6 +1899,23 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -1749,6 +1954,15 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1756,6 +1970,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1859,6 +2079,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -1896,6 +2122,18 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/speakeasy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/speakeasy/-/speakeasy-2.0.0.tgz",
+      "integrity": "sha512-lW2A2s5LKi8rwu77ewisuUOtlCydF/hmQSOJjpTqTj1gZLkNgTaYnyvfxy2WBr4T/h+9c4g8HIITfj83OkFQFw==",
+      "license": "MIT",
+      "dependencies": {
+        "base32.js": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -1915,6 +2153,32 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2064,6 +2328,26 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2087,6 +2371,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yn": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,8 @@
         "@types/dotenv": "^8.2.3",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.13.9",
+        "@types/qrcode": "^1.5.5",
+        "@types/speakeasy": "^2.0.10",
         "@types/ws": "^8.18.0",
         "nodemon": "^3.1.9",
         "prisma": "^6.4.1",
@@ -831,6 +833,26 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/speakeasy": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/speakeasy/-/speakeasy-2.0.10.tgz",
+      "integrity": "sha512-QVRlDW5r4yl7p7xkNIbAIC/JtyOcClDIIdKfuG7PWdDT1MmyhtXSANsildohy0K+Lmvf/9RUtLbNLMacvrVwxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "fastify": "^5.2.1",
     "fastify-plugin": "^5.0.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.10.1",
     "qrcode": "^1.5.4",
     "speakeasy": "^2.0.0"
   },
@@ -30,6 +31,7 @@
     "@types/dotenv": "^8.2.3",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.13.9",
+    "@types/nodemailer": "^6.4.17",
     "@types/qrcode": "^1.5.5",
     "@types/speakeasy": "^2.0.10",
     "@types/ws": "^8.18.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,8 @@
     "@types/dotenv": "^8.2.3",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.13.9",
+    "@types/qrcode": "^1.5.5",
+    "@types/speakeasy": "^2.0.10",
     "@types/ws": "^8.18.0",
     "nodemon": "^3.1.9",
     "prisma": "^6.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,9 @@
     "dotenv": "^16.4.7",
     "fastify": "^5.2.1",
     "fastify-plugin": "^5.0.1",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "qrcode": "^1.5.4",
+    "speakeasy": "^2.0.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.3",

--- a/backend/prisma/migrations/20250429000636_init/migration.sql
+++ b/backend/prisma/migrations/20250429000636_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId]` on the table `RefreshToken` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_userId_key" ON "RefreshToken"("userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,7 +30,7 @@ model User {
 
 model RefreshToken {
   id        Int      @id @default(autoincrement())
-  userId    Int
+  userId    Int      @unique
   token     String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -20,4 +20,8 @@ export const env = {
   googleCallbackUrl: getEnv('GOOGLE_CALLBACK_URL'),
 
   jwtSecret: getEnv('JWT_SECRET'),
+
+  mailerUser: getEnv('MAILER_USER'),
+  mailerPass: getEnv('MAILER_PASS'),
+  mailerLink: getEnv('MAILER_LINK'),
 };

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -14,4 +14,9 @@ export const config = {
     expiresIn: '1h',
     refreshExpiresIn: '7d',
   },
+  mailer: {
+    user: env.mailerUser,
+    pass: env.mailerPass,
+    link: env.mailerLink,
+  },
 };

--- a/backend/src/handlers/2fa.handler.ts
+++ b/backend/src/handlers/2fa.handler.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { twoFAService } from '../services';
-import { ERROR_MESSAGE, SUCCESS_MESSAGE } from '../lib';
+import authHandler from './auth.handler';
+import { mailer, jwtUtil, ERROR_MESSAGE, SUCCESS_MESSAGE } from '../lib';
 
 const twoFAHandler = () => {
   /**
@@ -46,9 +47,11 @@ const twoFAHandler = () => {
           .send(ERROR_MESSAGE.invalidToken);
       }
 
-      return reply
-        .status(SUCCESS_MESSAGE.verify2FA.status)
-        .send(SUCCESS_MESSAGE.verify2FA);
+      return authHandler.finalizeLogin(
+        reply,
+        userId,
+        SUCCESS_MESSAGE.verify2FA,
+      );
     } catch (error) {
       req.log.error(error);
       return reply
@@ -57,9 +60,73 @@ const twoFAHandler = () => {
     }
   };
 
+  /**
+   * 2FA 코드 초기화 핸들러
+   */
+  const resetRequest = async (req: FastifyRequest, reply: FastifyReply) => {
+    const userId = req.user.userId;
+
+    const user = await twoFAService.findUserById(userId);
+    if (!user) {
+      return reply
+        .status(ERROR_MESSAGE.notFound.status)
+        .send(ERROR_MESSAGE.notFound);
+    }
+
+    const resetToken = jwtUtil.signResetToken({ userId });
+    try {
+      await mailer.sendResetEmail(user.email, resetToken);
+      return reply
+        .status(SUCCESS_MESSAGE.sendMail.status)
+        .send(SUCCESS_MESSAGE.sendMail);
+    } catch (error) {
+      req.log.error(error);
+      return reply
+        .status(ERROR_MESSAGE.serverError.status)
+        .send(ERROR_MESSAGE.serverError);
+    }
+  };
+
+  const resetConfirm = async (
+    req: FastifyRequest<{ Querystring: { token: string } }>,
+    reply: FastifyReply,
+  ) => {
+    const { token } = req.query;
+
+    if (!token) {
+      return reply
+        .status(ERROR_MESSAGE.invalidToken.status)
+        .send(ERROR_MESSAGE.invalidToken);
+    }
+
+    try {
+      const decoded = jwtUtil.verifyToken(token);
+
+      const userId = decoded.userId;
+
+      if (!userId) {
+        return reply
+          .status(ERROR_MESSAGE.invalidToken.status)
+          .send(ERROR_MESSAGE.invalidToken);
+      }
+
+      await twoFAService.reset2FA(userId);
+
+      return reply.code(200).send({
+        ...SUCCESS_MESSAGE.reset2FA,
+      });
+    } catch (error) {
+      req.log.error(error);
+      return reply
+        .status(ERROR_MESSAGE.invalidToken.status)
+        .send(ERROR_MESSAGE.invalidToken);
+    }
+  };
   return {
     setup,
     verify,
+    resetRequest,
+    resetConfirm,
   };
 };
 

--- a/backend/src/handlers/2fa.handler.ts
+++ b/backend/src/handlers/2fa.handler.ts
@@ -27,12 +27,9 @@ const twoFAHandler = () => {
   /**
    * 2FA 코드 검증 핸들러
    */
-  const verify = async (
-    req: FastifyRequest<{ Body: { code: string } }>,
-    reply: FastifyReply,
-  ) => {
+  const verify = async (req: FastifyRequest, reply: FastifyReply) => {
     const userId = req.user.userId;
-    const { code } = req.body;
+    const { code } = req.body as { code: string };
 
     if (!code) {
       return reply

--- a/backend/src/handlers/2fa.handler.ts
+++ b/backend/src/handlers/2fa.handler.ts
@@ -12,8 +12,8 @@ const twoFAHandler = () => {
     try {
       const result = await twoFAService.generate2FASetup(userId);
 
-      return reply.status(SUCCESS_MESSAGE.generate2FASuccess.status).send({
-        ...SUCCESS_MESSAGE.generate2FASuccess,
+      return reply.status(SUCCESS_MESSAGE.generate2FA.status).send({
+        ...SUCCESS_MESSAGE.generate2FA,
         qrCode: result.qrCode,
       });
     } catch (error) {
@@ -50,8 +50,8 @@ const twoFAHandler = () => {
       }
 
       return reply
-        .status(SUCCESS_MESSAGE.verify2FASuccess.status)
-        .send(SUCCESS_MESSAGE.verify2FASuccess);
+        .status(SUCCESS_MESSAGE.verify2FA.status)
+        .send(SUCCESS_MESSAGE.verify2FA);
     } catch (error) {
       req.log.error(error);
       return reply

--- a/backend/src/handlers/2fa.handler.ts
+++ b/backend/src/handlers/2fa.handler.ts
@@ -1,0 +1,69 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { twoFAService } from '../services';
+import { ERROR_MESSAGE, SUCCESS_MESSAGE } from '../lib';
+
+const twoFAHandler = () => {
+  /**
+   * 2FA 설정용 QR코드 생성 핸들러
+   */
+  const setup = async (req: FastifyRequest, reply: FastifyReply) => {
+    const userId = req.user.id;
+
+    try {
+      const result = await twoFAService.generate2FASetup(userId);
+
+      return reply.status(SUCCESS_MESSAGE.generate2FASuccess.status).send({
+        ...SUCCESS_MESSAGE.generate2FASuccess,
+        qrCode: result.qrCode,
+      });
+    } catch (error) {
+      req.log.error(error);
+      return reply
+        .status(ERROR_MESSAGE.serverError.status)
+        .send(ERROR_MESSAGE.serverError);
+    }
+  };
+
+  /**
+   * 2FA 코드 검증 핸들러
+   */
+  const verify = async (
+    req: FastifyRequest<{ Body: { code: string } }>,
+    reply: FastifyReply,
+  ) => {
+    const userId = req.user.id;
+    const { code } = req.body;
+
+    if (!code) {
+      return reply
+        .status(ERROR_MESSAGE.badRequest.status)
+        .send(ERROR_MESSAGE.badRequest);
+    }
+
+    try {
+      const isVerified = await twoFAService.verify2FACode(userId, code);
+
+      if (!isVerified) {
+        return reply
+          .status(ERROR_MESSAGE.invalidToken.status)
+          .send(ERROR_MESSAGE.invalidToken);
+      }
+
+      return reply
+        .status(SUCCESS_MESSAGE.verify2FASuccess.status)
+        .send(SUCCESS_MESSAGE.verify2FASuccess);
+    } catch (error) {
+      req.log.error(error);
+      return reply
+        .status(ERROR_MESSAGE.serverError.status)
+        .send(ERROR_MESSAGE.serverError);
+    }
+  };
+
+  return {
+    setup,
+    verify,
+  };
+};
+
+export default twoFAHandler();

--- a/backend/src/handlers/2fa.handler.ts
+++ b/backend/src/handlers/2fa.handler.ts
@@ -7,7 +7,7 @@ const twoFAHandler = () => {
    * 2FA 설정용 QR코드 생성 핸들러
    */
   const setup = async (req: FastifyRequest, reply: FastifyReply) => {
-    const userId = req.user.id;
+    const userId = req.user.userId;
 
     try {
       const result = await twoFAService.generate2FASetup(userId);
@@ -31,7 +31,7 @@ const twoFAHandler = () => {
     req: FastifyRequest<{ Body: { code: string } }>,
     reply: FastifyReply,
   ) => {
-    const userId = req.user.id;
+    const userId = req.user.userId;
     const { code } = req.body;
 
     if (!code) {

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -22,31 +22,14 @@ const authHandler = () => {
         const tmpToken = jwtUtil.signTmpToken({ userId: user.id });
 
         return reply
-          .header('Temp-Authorization', `Bearer ${tmpToken}`)
+          .header('Authorization', `Bearer ${tmpToken}`)
           .code(SUCCESS_MESSAGE.need2FA.status)
           .send({
             ...SUCCESS_MESSAGE.need2FA,
           });
       }
 
-      const accessToken = jwtUtil.signAccessToken({ userId: user.id });
-      const refreshToken = jwtUtil.signRefreshToken({ userId: user.id });
-      await authService.saveRefreshToken(user.id, refreshToken);
-
-      return reply
-        .setCookie('refreshToken', refreshToken, {
-          httpOnly: true,
-          secure: false, // 개발 환경에서는 false
-          sameSite: 'strict',
-          path: '/',
-          maxAge: 60 * 60 * 24 * 7,
-        })
-        .header('Authorization', `Bearer ${accessToken}`)
-        .code(SUCCESS_MESSAGE.loginOK.status)
-        .send({
-          ...SUCCESS_MESSAGE.loginOK,
-          user,
-        });
+      return finalizeLogin(reply, user.id, SUCCESS_MESSAGE.loginOK);
     } catch (err) {
       req.log.error(err);
       return reply
@@ -110,7 +93,33 @@ const authHandler = () => {
     }
   };
 
-  return { login, googleCallback, refresh, logout };
+  const finalizeLogin = async (
+    reply: FastifyReply,
+    id: number,
+    successMessage: { success: true; status: number; message: string },
+  ) => {
+    const accessToken = jwtUtil.signAccessToken({ userId: id });
+    const refreshToken = jwtUtil.signRefreshToken({ userId: id });
+
+    await authService.saveRefreshToken(id, refreshToken);
+
+    const user = await authService.findUserById(id);
+    return reply
+      .setCookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: false,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 7,
+      })
+      .header('Authorization', `Bearer ${accessToken}`)
+      .code(successMessage.status)
+      .send({
+        ...successMessage,
+        user,
+      });
+  };
+  return { login, googleCallback, refresh, logout, finalizeLogin };
 };
 
 export default authHandler();

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -18,17 +18,28 @@ const authHandler = () => {
       const googleUser = await jwtUtil.getGoogleUser(access_token);
       const user = await authService.saveUser(googleUser);
 
+      if (user.twoFactorEnabled) {
+        const tmpToken = jwtUtil.signTmpToken({ userId: user.id });
+
+        return reply
+          .header('Temp-Authorization', `Bearer ${tmpToken}`)
+          .code(SUCCESS_MESSAGE.need2FA.status)
+          .send({
+            ...SUCCESS_MESSAGE.need2FA,
+          });
+      }
+
       const accessToken = jwtUtil.signAccessToken({ userId: user.id });
       const refreshToken = jwtUtil.signRefreshToken({ userId: user.id });
       await authService.saveRefreshToken(user.id, refreshToken);
 
-      reply
+      return reply
         .setCookie('refreshToken', refreshToken, {
           httpOnly: true,
-          secure: false, // 개발 환경에서는 false, 배포 시 true
+          secure: false, // 개발 환경에서는 false
           sameSite: 'strict',
           path: '/',
-          maxAge: 60 * 60 * 24 * 7, // 7일
+          maxAge: 60 * 60 * 24 * 7,
         })
         .header('Authorization', `Bearer ${accessToken}`)
         .code(SUCCESS_MESSAGE.loginOK.status)
@@ -38,7 +49,7 @@ const authHandler = () => {
         });
     } catch (err) {
       req.log.error(err);
-      reply
+      return reply
         .code(ERROR_MESSAGE.serverError.status)
         .send(ERROR_MESSAGE.serverError);
     }

--- a/backend/src/handlers/auth.handler.ts
+++ b/backend/src/handlers/auth.handler.ts
@@ -1,116 +1,105 @@
-import * as service from '../services';
-import {
-  SUCCESS_MESSAGE,
-  ERROR_MESSAGE,
-  signAccessToken,
-  signRefreshToken,
-  verifyToken,
-  getGoogleUser,
-} from '../lib';
+import { authService } from '../services';
+import { jwtUtil, SUCCESS_MESSAGE, ERROR_MESSAGE } from '../lib';
 import { FastifyRequest, FastifyReply } from 'fastify';
 
-export async function googleCallbackHandler(
-  req: FastifyRequest,
-  reply: FastifyReply,
-) {
-  try {
-    const token =
-      await req.server.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(
-        req,
+const authHandler = () => {
+  const login = async (req: FastifyRequest, reply: FastifyReply) => {
+    reply.redirect('/auth/google');
+  };
+
+  const googleCallback = async (req: FastifyRequest, reply: FastifyReply) => {
+    try {
+      const token =
+        await req.server.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(
+          req,
+        );
+      const { access_token } = token.token as any;
+
+      const googleUser = await jwtUtil.getGoogleUser(access_token);
+      const user = await authService.saveUser(googleUser);
+
+      const accessToken = jwtUtil.signAccessToken({ userId: user.id });
+      const refreshToken = jwtUtil.signRefreshToken({ userId: user.id });
+      await authService.saveRefreshToken(user.id, refreshToken);
+
+      reply
+        .setCookie('refreshToken', refreshToken, {
+          httpOnly: true,
+          secure: false, // 개발 환경에서는 false, 배포 시 true
+          sameSite: 'strict',
+          path: '/',
+          maxAge: 60 * 60 * 24 * 7, // 7일
+        })
+        .header('Authorization', `Bearer ${accessToken}`)
+        .code(SUCCESS_MESSAGE.loginOK.status)
+        .send({
+          ...SUCCESS_MESSAGE.loginOK,
+          user,
+        });
+    } catch (err) {
+      req.log.error(err);
+      reply
+        .code(ERROR_MESSAGE.serverError.status)
+        .send(ERROR_MESSAGE.serverError);
+    }
+  };
+
+  const refresh = async (req: FastifyRequest, reply: FastifyReply) => {
+    const refreshToken = req.cookies.refreshToken;
+    if (!refreshToken) {
+      return reply
+        .code(ERROR_MESSAGE.unauthorized.status)
+        .send(ERROR_MESSAGE.unauthorized);
+    }
+
+    try {
+      const decoded = jwtUtil.verifyToken(refreshToken);
+      const { userId, tokenRecord } = await authService.findRefreshToken(
+        decoded.userId,
+        refreshToken,
       );
-    const { access_token } = token.token as any;
 
-    const googleUser = await getGoogleUser(access_token);
-    const user = await service.saveUser(googleUser);
-    const accessToken = signAccessToken({ userId: user.id });
-    const refreshToken = signRefreshToken({ userId: user.id });
-    await service.saveRefreshToken(user.id, refreshToken);
-    reply
-      .setCookie('refreshToken', refreshToken, {
-        httpOnly: true,
-        secure: false, // 개발 환경에서는 false로 설정 추후 수정
-        sameSite: 'strict', // CSRF 방지
-        path: '/', // 이 경로 요청 시에만 자동 첨부
-        maxAge: 60 * 60 * 24 * 7, // 7일
-      })
-      .header('Authorization', `Bearer ${accessToken}`)
-      .code(SUCCESS_MESSAGE.loginOK.status)
-      .send({
-        ...SUCCESS_MESSAGE.loginOK,
-        user,
+      if (!tokenRecord) {
+        return reply
+          .code(ERROR_MESSAGE.invalidToken.status)
+          .send(ERROR_MESSAGE.invalidToken);
+      }
+
+      const newAccessToken = jwtUtil.signAccessToken({ userId });
+      return reply.send({
+        ...SUCCESS_MESSAGE.refreshToken,
+        accessToken: newAccessToken,
       });
-  } catch (err) {
-    req.log.error(err);
-    reply
-      .code(ERROR_MESSAGE.serverError.status)
-      .send(ERROR_MESSAGE.serverError);
-  }
-}
-
-export async function logoutHandler(req: FastifyRequest, reply: FastifyReply) {
-  const refreshToken = req.cookies.refreshToken;
-
-  if (!refreshToken) {
-    return reply
-      .code(ERROR_MESSAGE.unauthorized.status)
-      .send(ERROR_MESSAGE.unauthorized);
-  }
-
-  try {
-    await service.deleteRefreshToken(refreshToken);
-
-    reply.clearCookie('refreshToken', {
-      path: '/',
-    });
-
-    return reply
-      .code(SUCCESS_MESSAGE.logoutOK.status)
-      .send(SUCCESS_MESSAGE.logoutOK);
-  } catch (err) {
-    return reply
-      .code(ERROR_MESSAGE.serverError.status)
-      .send(ERROR_MESSAGE.serverError);
-  }
-}
-
-export async function refreshHandler(req: FastifyRequest, reply: FastifyReply) {
-  const refreshToken = req.cookies.refreshToken;
-
-  if (!refreshToken) {
-    return reply
-      .code(ERROR_MESSAGE.unauthorized.status)
-      .send(ERROR_MESSAGE.unauthorized);
-  }
-
-  try {
-    const decoded = verifyToken(refreshToken);
-    const { userId, tokenRecord } = await service.findRefreshToken(
-      decoded.userId,
-      refreshToken,
-    );
-
-    if (!tokenRecord) {
+    } catch (err) {
       return reply
         .code(ERROR_MESSAGE.invalidToken.status)
         .send(ERROR_MESSAGE.invalidToken);
     }
+  };
 
-    const newAccessToken = signAccessToken({ userId });
+  const logout = async (req: FastifyRequest, reply: FastifyReply) => {
+    const refreshToken = req.cookies.refreshToken;
+    if (!refreshToken) {
+      return reply
+        .code(ERROR_MESSAGE.unauthorized.status)
+        .send(ERROR_MESSAGE.unauthorized);
+    }
 
-    return reply.send({
-      ...SUCCESS_MESSAGE.refreshToken,
-      accessToken: newAccessToken,
-    });
-  } catch (err) {
-    return reply
-      .code(ERROR_MESSAGE.invalidToken.status)
-      .send(ERROR_MESSAGE.invalidToken);
-  }
-}
+    try {
+      await authService.deleteRefreshToken(refreshToken);
+      reply.clearCookie('refreshToken', { path: '/' });
 
-export async function loginRedirectHandler(
-  req: FastifyRequest,
-  reply: FastifyReply,
-) {
-  reply.redirect('/auth/google');
-}
+      return reply
+        .code(SUCCESS_MESSAGE.logoutOK.status)
+        .send(SUCCESS_MESSAGE.logoutOK);
+    } catch (err) {
+      return reply
+        .code(ERROR_MESSAGE.serverError.status)
+        .send(ERROR_MESSAGE.serverError);
+    }
+  };
+
+  return { login, googleCallback, refresh, logout };
+};
+
+export default authHandler();

--- a/backend/src/handlers/index.ts
+++ b/backend/src/handlers/index.ts
@@ -1,1 +1,1 @@
-export * from './auth.handler';
+export { default as authHandler } from './auth.handler';

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -31,6 +31,11 @@ const ERROR_MESSAGE = {
     status: 401,
     message: 'Token Expired',
   },
+  not2FA: {
+    success: false,
+    status: 401,
+    message: 'Two-factor required',
+  },
   forbidden: {
     success: false,
     status: 403,
@@ -93,6 +98,11 @@ const SUCCESS_MESSAGE = {
     status: 200,
     success: true,
     message: '2FA Verify Success!',
+  },
+  need2FA: {
+    success: true,
+    status: 200,
+    message: 'tmp Login Success!',
   },
 } as const;
 

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -104,6 +104,16 @@ const SUCCESS_MESSAGE = {
     status: 200,
     message: 'tmp Login Success!',
   },
+  sendMail: {
+    success: true,
+    status: 201,
+    message: 'send reset email Success!',
+  },
+  reset2FA: {
+    success: true,
+    status: 200,
+    message: 'reset 2FA Success!',
+  },
 } as const;
 
 export { ERROR_MESSAGE, SUCCESS_MESSAGE };

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { verify } from 'crypto';
+
 const ERROR_MESSAGE = {
   badRequest: {
     success: false,
@@ -81,6 +83,16 @@ const SUCCESS_MESSAGE = {
     status: 201,
     success: true,
     message: 'register Success!',
+  },
+  generate2FA: {
+    status: 200,
+    success: true,
+    message: '2FA Setup Success!',
+  },
+  verify2FA: {
+    status: 200,
+    success: true,
+    message: '2FA Verify Success!',
   },
 } as const;
 

--- a/backend/src/lib/index.ts
+++ b/backend/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './constants';
 export { default as jwtUtil } from './jwt';
+export { default as mailer } from './mailer';

--- a/backend/src/lib/index.ts
+++ b/backend/src/lib/index.ts
@@ -1,2 +1,2 @@
 export * from './constants';
-export * from './jwt';
+export { default as jwtUtil } from './jwt';

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -23,6 +23,14 @@ const jwtUtil = () => {
     return jwt.sign(payload, secret, options);
   };
 
+  const signTmpToken = (payload: object) => {
+    const secret: Secret = config.jwt.secret as Secret;
+    const options: SignOptions = {
+      expiresIn: '5m',
+    };
+    return jwt.sign({ ...payload, twoFactorPending: true }, secret, options);
+  };
+
   const signRefreshToken = (payload: object) => {
     const secret: Secret = config.jwt.secret as Secret;
     const options: SignOptions = {
@@ -38,6 +46,7 @@ const jwtUtil = () => {
   const verifyAccessToken = async (
     request: FastifyRequest,
     reply: FastifyReply,
+    options: { expectTmpToken: boolean },
   ) => {
     const authHeader = request.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
@@ -50,6 +59,11 @@ const jwtUtil = () => {
 
     try {
       const decoded = verifyToken(token);
+      if (decoded.twoFactorPending && !options.expectTmpToken) {
+        return reply
+          .code(ERROR_MESSAGE.not2FA.status)
+          .send(ERROR_MESSAGE.not2FA);
+      }
       request.user = decoded;
     } catch (err) {
       if (err instanceof jwt.TokenExpiredError) {
@@ -67,6 +81,7 @@ const jwtUtil = () => {
     getGoogleUser,
     signAccessToken,
     signRefreshToken,
+    signTmpToken,
     verifyToken,
     verifyAccessToken,
   };

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -25,10 +25,9 @@ const jwtUtil = () => {
 
   const signTmpToken = (payload: object) => {
     const secret: Secret = config.jwt.secret as Secret;
-    const options: SignOptions = {
+    return jwt.sign({ ...payload, twoFactorPending: true }, secret, {
       expiresIn: '5m',
-    };
-    return jwt.sign({ ...payload, twoFactorPending: true }, secret, options);
+    });
   };
 
   const signRefreshToken = (payload: object) => {
@@ -37,6 +36,10 @@ const jwtUtil = () => {
       expiresIn: config.jwt.refreshExpiresIn as SignOptions['expiresIn'],
     };
     return jwt.sign(payload, secret, options);
+  };
+  const signResetToken = (payload: { userId: number }) => {
+    const secret = config.jwt.secret;
+    return jwt.sign(payload, secret, { expiresIn: '5m' });
   };
 
   const verifyToken = (token: string): TokenPayload => {
@@ -81,6 +84,7 @@ const jwtUtil = () => {
     getGoogleUser,
     signAccessToken,
     signRefreshToken,
+    signResetToken,
     signTmpToken,
     verifyToken,
     verifyAccessToken,

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -3,63 +3,73 @@ import { config } from '../config';
 import { FastifyRequest, FastifyReply, TokenPayload } from 'fastify';
 import { ERROR_MESSAGE } from './constants';
 
-export async function getGoogleUser(accessToken: string) {
-  const res = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
-	headers: {
-	  Authorization: `Bearer ${accessToken}`,
-	},
-  });
+const jwtUtil = () => {
+  const getGoogleUser = async (accessToken: string) => {
+    const res = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
 
-  if (!res.ok) throw new Error('Google user fetch failed');
-  return await res.json();
-}
-
-export function signAccessToken(payload: object) {
-  const secret: Secret = config.jwt.secret as Secret;
-  const options: SignOptions = {
-    expiresIn: config.jwt.expiresIn as SignOptions['expiresIn'],
+    if (!res.ok) throw new Error('Google user fetch failed');
+    return await res.json();
   };
 
-  return jwt.sign(payload, secret, options);
-}
-
-export function signRefreshToken(payload: object) {
-  const secret: Secret = config.jwt.secret as Secret;
-  const options: SignOptions = {
-    expiresIn: config.jwt.refreshExpiresIn as SignOptions['expiresIn'],
+  const signAccessToken = (payload: object) => {
+    const secret: Secret = config.jwt.secret as Secret;
+    const options: SignOptions = {
+      expiresIn: config.jwt.expiresIn as SignOptions['expiresIn'],
+    };
+    return jwt.sign(payload, secret, options);
   };
 
-  return jwt.sign(payload, secret, options);
-}
+  const signRefreshToken = (payload: object) => {
+    const secret: Secret = config.jwt.secret as Secret;
+    const options: SignOptions = {
+      expiresIn: config.jwt.refreshExpiresIn as SignOptions['expiresIn'],
+    };
+    return jwt.sign(payload, secret, options);
+  };
 
-export function verifyToken(token: string): TokenPayload {
-  return jwt.verify(token, config.jwt.secret) as TokenPayload;
-}
+  const verifyToken = (token: string): TokenPayload => {
+    return jwt.verify(token, config.jwt.secret) as TokenPayload;
+  };
 
-export async function verifyAccessToken(
-  request: FastifyRequest,
-  reply: FastifyReply,
-) {
-  const authHeader = request.headers.authorization;
-  if (!authHeader?.startsWith('Bearer ')) {
-    return reply
-      .code(ERROR_MESSAGE.unauthorized.status)
-      .send(ERROR_MESSAGE.unauthorized);
-  }
-
-  const token = authHeader.split(' ')[1];
-
-  try {
-    const decoded = verifyToken(token);
-    request.user = decoded;
-  } catch (err) {
-    if (err instanceof jwt.TokenExpiredError) {
+  const verifyAccessToken = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const authHeader = request.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
       return reply
-        .code(ERROR_MESSAGE.expired.status)
-        .send(ERROR_MESSAGE.expired);
+        .code(ERROR_MESSAGE.unauthorized.status)
+        .send(ERROR_MESSAGE.unauthorized);
     }
-    return reply
-      .code(ERROR_MESSAGE.invalidToken.status)
-      .send(ERROR_MESSAGE.invalidToken);
-  }
-}
+
+    const token = authHeader.split(' ')[1];
+
+    try {
+      const decoded = verifyToken(token);
+      request.user = decoded;
+    } catch (err) {
+      if (err instanceof jwt.TokenExpiredError) {
+        return reply
+          .code(ERROR_MESSAGE.expired.status)
+          .send(ERROR_MESSAGE.expired);
+      }
+      return reply
+        .code(ERROR_MESSAGE.invalidToken.status)
+        .send(ERROR_MESSAGE.invalidToken);
+    }
+  };
+
+  return {
+    getGoogleUser,
+    signAccessToken,
+    signRefreshToken,
+    verifyToken,
+    verifyAccessToken,
+  };
+};
+
+export default jwtUtil();

--- a/backend/src/lib/mailer.ts
+++ b/backend/src/lib/mailer.ts
@@ -1,0 +1,28 @@
+import nodemailer from 'nodemailer';
+import { config } from '../config';
+
+const transporter = nodemailer.createTransport({
+  service: 'Gmail',
+  auth: {
+    user: config.mailer.user,
+    pass: config.mailer.pass,
+  },
+});
+const mailer = () => {
+  const sendResetEmail = async (to: string, resetToken: string) => {
+    const resetLink = `${config.mailer.link}${resetToken}`;
+
+    await transporter.sendMail({
+      from: `"Great Ping Pong" <${config.mailer.user}>`,
+      to,
+      subject: 'Reset Your 2FA Authentication',
+      text: `Hello!\n\nClick this link to reset your 2FA authentication:\n\n${resetLink}\n\nThis link will expire in 5 minutes.\n\nIf you did not request this, please ignore this email.`,
+    });
+  };
+
+  return {
+    sendResetEmail,
+  };
+};
+
+export default mailer();

--- a/backend/src/plugins/google-oauth.ts
+++ b/backend/src/plugins/google-oauth.ts
@@ -15,5 +15,7 @@ export default fp(async (fastify) => {
     },
     startRedirectPath: '/auth/google',
     callbackUri: env.googleCallbackUrl,
+    generateStateFunction: () => 'test-state', // 테스트 끝나면 반드시 제거
+    checkStateFunction: () => true, // 테스트 끝나면 반드시 제거
   });
 });

--- a/backend/src/routes/2fa.ts
+++ b/backend/src/routes/2fa.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance } from 'fastify';
+import twoFAHandler from '../handlers/2fa.handler';
+import { generate2FASchema, verify2FASchema } from '../schema/2fa.schema';
+
+const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
+  fastify.get('/setup', { schema: generate2FASchema }, twoFAHandler.setup);
+
+  fastify.post('/verify', { schema: verify2FASchema }, twoFAHandler.verify);
+};
+
+export default twoFARoute;

--- a/backend/src/routes/2fa.ts
+++ b/backend/src/routes/2fa.ts
@@ -6,7 +6,9 @@ const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
     '/setup',
     {
-      preHandler: [jwtUtil.verifyAccessToken],
+      preHandler: async (req, reply) => {
+        await jwtUtil.verifyAccessToken(req, reply, { expectTmpToken: false });
+      },
       schema: generate2FASchema,
     },
     twoFAHandler.setup,
@@ -15,7 +17,9 @@ const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
   fastify.post(
     '/verify',
     {
-      preHandler: [jwtUtil.verifyAccessToken],
+      preHandler: async (req, reply) => {
+        await jwtUtil.verifyAccessToken(req, reply, { expectTmpToken: true });
+      },
       schema: verify2FASchema,
     },
     twoFAHandler.verify,

--- a/backend/src/routes/2fa.ts
+++ b/backend/src/routes/2fa.ts
@@ -1,7 +1,13 @@
 import { FastifyInstance } from 'fastify';
 import twoFAHandler from '../handlers/2fa.handler';
-import { generate2FASchema, verify2FASchema } from '../schema/2fa.schema';
+import {
+  generate2FASchema,
+  verify2FASchema,
+  resetRequestSchema,
+  resetConfirmSchema,
+} from '../schema/2fa.schema';
 import { jwtUtil } from '../lib';
+
 const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
   fastify.get(
     '/setup',
@@ -23,6 +29,23 @@ const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
       schema: verify2FASchema,
     },
     twoFAHandler.verify,
+  );
+
+  fastify.post(
+    '/reset/request',
+    {
+      preHandler: async (req, reply) => {
+        await jwtUtil.verifyAccessToken(req, reply, { expectTmpToken: true });
+      },
+      schema: resetRequestSchema,
+    },
+    twoFAHandler.resetRequest,
+  );
+
+  fastify.get(
+    '/reset/confirm',
+    { schema: resetConfirmSchema },
+    twoFAHandler.resetConfirm,
   );
 };
 

--- a/backend/src/routes/2fa.ts
+++ b/backend/src/routes/2fa.ts
@@ -1,11 +1,25 @@
 import { FastifyInstance } from 'fastify';
 import twoFAHandler from '../handlers/2fa.handler';
 import { generate2FASchema, verify2FASchema } from '../schema/2fa.schema';
-
+import { jwtUtil } from '../lib';
 const twoFARoute = async (fastify: FastifyInstance): Promise<void> => {
-  fastify.get('/setup', { schema: generate2FASchema }, twoFAHandler.setup);
+  fastify.get(
+    '/setup',
+    {
+      preHandler: [jwtUtil.verifyAccessToken],
+      schema: generate2FASchema,
+    },
+    twoFAHandler.setup,
+  );
 
-  fastify.post('/verify', { schema: verify2FASchema }, twoFAHandler.verify);
+  fastify.post(
+    '/verify',
+    {
+      preHandler: [jwtUtil.verifyAccessToken],
+      schema: verify2FASchema,
+    },
+    twoFAHandler.verify,
+  );
 };
 
 export default twoFARoute;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,12 +1,12 @@
 import { FastifyInstance } from 'fastify';
-import * as handler from '../handlers/auth.handler';
+import { authHandler } from '../handlers';
 import { loginSchema, refreshSchema, logoutSchema } from '../schema';
 
 const authRoute = async (fastify: FastifyInstance): Promise<void> => {
-  fastify.get('/login', handler.loginRedirectHandler);
-  fastify.get('/google/callback', handler.googleCallbackHandler);
-  fastify.post('/refresh', { schema: refreshSchema }, handler.refreshHandler);
-  fastify.get('/logout', { schema: logoutSchema }, handler.logoutHandler);
+  fastify.get('/login', authHandler.login);
+  fastify.get('/google/callback', authHandler.googleCallback);
+  fastify.post('/refresh', { schema: refreshSchema }, authHandler.refresh);
+  fastify.get('/logout', { schema: logoutSchema }, authHandler.logout);
 };
 
 export default authRoute;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,7 +3,7 @@ import * as handler from '../handlers/auth.handler';
 import { loginSchema, refreshSchema, logoutSchema } from '../schema';
 
 const authRoute = async (fastify: FastifyInstance): Promise<void> => {
-  fastify.get('/login', { schema: loginSchema }, handler.loginRedirectHandler);
+  fastify.get('/login', handler.loginRedirectHandler);
   fastify.get('/google/callback', handler.googleCallbackHandler);
   fastify.post('/refresh', { schema: refreshSchema }, handler.refreshHandler);
   fastify.get('/logout', { schema: logoutSchema }, handler.logoutHandler);

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import authRoute from './auth';
+import twoFARoute from './2fa';
 
 const routes = async (fastify: FastifyInstance): Promise<void> => {
   fastify.register(authRoute, { prefix: '/api/auth' });
+  fastify.register(twoFARoute, { prefix: '/api/2fa' });
 };
 
 export default routes;

--- a/backend/src/schema/2fa.schema.ts
+++ b/backend/src/schema/2fa.schema.ts
@@ -1,0 +1,24 @@
+import {
+  generate2FASetupResponse,
+  verify2FARequest,
+  verify2FAResponse,
+} from './2fa.typebox';
+
+/**
+ * 2FA QR 생성 API 스키마
+ */
+export const generate2FASchema = {
+  response: {
+    200: generate2FASetupResponse,
+  },
+};
+
+/**
+ * 2FA 코드 검증 API 스키마
+ */
+export const verify2FASchema = {
+  body: verify2FARequest,
+  response: {
+    200: verify2FAResponse,
+  },
+};

--- a/backend/src/schema/2fa.schema.ts
+++ b/backend/src/schema/2fa.schema.ts
@@ -2,6 +2,9 @@ import {
   TGenerate2FASetupResponse,
   TVerify2FARequest,
   TVerify2FAResponse,
+  TResetRequestResponse,
+  TResetConfirmQuery,
+  TResetConfirmResponse,
 } from './2fa.typebox';
 
 /**
@@ -20,5 +23,18 @@ export const verify2FASchema = {
   body: TVerify2FARequest,
   response: {
     200: TVerify2FAResponse,
+  },
+};
+
+export const resetRequestSchema = {
+  response: {
+    200: TResetRequestResponse,
+  },
+};
+
+export const resetConfirmSchema = {
+  querystring: TResetConfirmQuery,
+  response: {
+    200: TResetConfirmResponse,
   },
 };

--- a/backend/src/schema/2fa.schema.ts
+++ b/backend/src/schema/2fa.schema.ts
@@ -1,7 +1,7 @@
 import {
-  generate2FASetupResponse,
-  verify2FARequest,
-  verify2FAResponse,
+  TGenerate2FASetupResponse,
+  TVerify2FARequest,
+  TVerify2FAResponse,
 } from './2fa.typebox';
 
 /**
@@ -9,7 +9,7 @@ import {
  */
 export const generate2FASchema = {
   response: {
-    200: generate2FASetupResponse,
+    200: TGenerate2FASetupResponse,
   },
 };
 
@@ -17,8 +17,8 @@ export const generate2FASchema = {
  * 2FA 코드 검증 API 스키마
  */
 export const verify2FASchema = {
-  body: verify2FARequest,
+  body: TVerify2FARequest,
   response: {
-    200: verify2FAResponse,
+    200: TVerify2FAResponse,
   },
 };

--- a/backend/src/schema/2fa.typebox.ts
+++ b/backend/src/schema/2fa.typebox.ts
@@ -30,6 +30,35 @@ export const TVerify2FAResponse = Type.Object({
   message: Type.String(),
 });
 
+/**
+ * 🔹 /api/2fa/reset-request
+ * - 요청 바디는 없음
+ * - 응답은 기본 성공 메시지
+ */
+export const TResetRequestResponse = Type.Object({
+  success: Type.Boolean(),
+  status: Type.Number(),
+  message: Type.String(),
+});
+
+/**
+ * 🔹 /api/2fa/reset-confirm
+ * - 요청 쿼리: token
+ * - 응답은 기본 성공 메시지
+ */
+export const TResetConfirmQuery = Type.Object({
+  token: Type.String(),
+});
+
+export const TResetConfirmResponse = Type.Object({
+  success: Type.Boolean(),
+  status: Type.Number(),
+  message: Type.String(),
+});
+
 export type Generate2FASetupResponse = Static<typeof TGenerate2FASetupResponse>;
 export type Verify2FARequest = Static<typeof TVerify2FARequest>;
 export type Verify2FAResponse = Static<typeof TVerify2FAResponse>;
+export type ResetRequestResponse = Static<typeof TResetRequestResponse>;
+export type ResetConfirmQuery = Static<typeof TResetConfirmQuery>;
+export type ResetConfirmResponse = Static<typeof TResetConfirmResponse>;

--- a/backend/src/schema/2fa.typebox.ts
+++ b/backend/src/schema/2fa.typebox.ts
@@ -1,0 +1,35 @@
+import { Type, Static } from '@sinclair/typebox';
+
+/**
+ * 2FA Setup (QR코드 생성) 성공 응답 스키마
+ */
+export const TGenerate2FASetupResponse = Type.Intersect([
+  Type.Object({
+    success: Type.Boolean(),
+    status: Type.Number(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    qrCode: Type.String(), // base64 인코딩된 QR 이미지 URL
+  }),
+]);
+
+/**
+ * 2FA Verify 요청 바디 스키마
+ */
+export const TVerify2FARequest = Type.Object({
+  code: Type.String({ minLength: 6, maxLength: 6 }), // 6자리 OTP 코드
+});
+
+/**
+ * 2FA Verify 성공 응답 스키마
+ */
+export const TVerify2FAResponse = Type.Object({
+  success: Type.Boolean(),
+  status: Type.Number(),
+  message: Type.String(),
+});
+
+export type Generate2FASetupResponse = Static<typeof TGenerate2FASetupResponse>;
+export type Verify2FARequest = Static<typeof TVerify2FARequest>;
+export type Verify2FAResponse = Static<typeof TVerify2FAResponse>;

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -55,9 +55,23 @@ const twoFAService = () => {
     return isVerified;
   };
 
+  const reset2FA = async (email: string) => {
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    return prisma.user.update({
+      where: { id: user.id },
+      data: {
+        twoFactorEnabled: false,
+        twoFactorSecret: null,
+      },
+    });
+  };
   return {
     generate2FASetup,
     verify2FACode,
+    reset2FA,
   };
 };
 

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -17,8 +17,7 @@ const twoFAService = () => {
     }
 
     const secret = speakeasy.generateSecret({
-      name: user.nickname,
-      issuer: 'Great-ping-pong',
+      name: `great-ping-pong (${user.nickname})`,
     });
 
     // QR코드 이미지 (Data URL)

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -1,0 +1,72 @@
+import speakeasy from 'speakeasy';
+import qrcode from 'qrcode';
+import { prisma } from '../plugins/prisma';
+
+const twoFAService = () => {
+  /**
+   * 2FA 설정을 위한 시크릿 키 생성 및 QR코드 반환
+   */
+  const generate2FASetup = async (userId: number) => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { nickname: true }, // nickname만 조회
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const secret = speakeasy.generateSecret({
+      name: user.nickname,
+      issuer: 'Great-ping-pong',
+    });
+
+    // QR코드 이미지 (Data URL)
+    const qrCode = await qrcode.toDataURL(secret.otpauth_url || '');
+
+    // DB에 시크릿 저장 (아직 활성화는 X)
+    await prisma.user.update({
+      where: { id: userId },
+      data: { twoFactorSecret: secret.base32 },
+    });
+
+    return {
+      qrCode, // QR코드 이미지 (클라이언트에서 이미지 태그의 src로 렌더링 가능)
+      secret: secret.base32, // 예비용
+    };
+  };
+
+  /**
+   * 사용자가 입력한 2FA 코드 검증 + 성공 시 활성화
+   */
+  const verify2FACode = async (userId: number, inputCode: string) => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user || !user.twoFactorSecret) return false;
+
+    const isVerified = speakeasy.totp.verify({
+      secret: user.twoFactorSecret,
+      encoding: 'base32',
+      token: inputCode,
+      window: 1,
+    });
+
+    if (isVerified) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { twoFactorEnabled: true },
+      });
+    }
+
+    return isVerified;
+  };
+
+  return {
+    generate2FASetup,
+    verify2FACode,
+  };
+};
+
+export default twoFAService();

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -26,7 +26,7 @@ const twoFAService = () => {
     // DB에 시크릿 저장 (아직 활성화는 X)
     await prisma.user.update({
       where: { id: userId },
-      data: { twoFactorSecret: secret.base32 },
+      data: { twoFactorSecret: secret.base32, twoFactorEnabled: true },
     });
 
     return {

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -36,7 +36,7 @@ const twoFAService = () => {
   };
 
   /**
-   * 사용자가 입력한 2FA 코드 검증 + 성공 시 활성화
+   * 사용자가 입력한 2FA 코드 검증
    */
   const verify2FACode = async (userId: number, inputCode: string) => {
     const user = await prisma.user.findUnique({
@@ -51,13 +51,6 @@ const twoFAService = () => {
       token: inputCode,
       window: 1,
     });
-
-    if (isVerified) {
-      await prisma.user.update({
-        where: { id: userId },
-        data: { twoFactorEnabled: true },
-      });
-    }
 
     return isVerified;
   };

--- a/backend/src/services/2fa.service.ts
+++ b/backend/src/services/2fa.service.ts
@@ -55,13 +55,18 @@ const twoFAService = () => {
     return isVerified;
   };
 
-  const reset2FA = async (email: string) => {
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) {
-      throw new Error('User not found');
-    }
+  const findUserById = async (userId: number) => {
+    return await prisma.user.findUnique({
+      where: { id: userId },
+    });
+  };
+
+  /**
+   * 2FA 비활성화
+   */
+  const reset2FA = async (id: number) => {
     return prisma.user.update({
-      where: { id: user.id },
+      where: { id },
       data: {
         twoFactorEnabled: false,
         twoFactorSecret: null,
@@ -72,6 +77,7 @@ const twoFAService = () => {
     generate2FASetup,
     verify2FACode,
     reset2FA,
+    findUserById,
   };
 };
 

--- a/backend/src/services/auth.sevice.ts
+++ b/backend/src/services/auth.sevice.ts
@@ -21,11 +21,10 @@ const authService = () => {
   };
 
   const saveRefreshToken = async (userId: number, token: string) => {
-    return prisma.refreshToken.create({
-      data: {
-        userId,
-        token,
-      },
+    return prisma.refreshToken.upsert({
+      where: { userId },
+      update: { token },
+      create: { userId, token },
     });
   };
 
@@ -34,7 +33,11 @@ const authService = () => {
       where: { token },
     });
   };
-
+  const findUserById = async (userId: number) => {
+    return await prisma.user.findUnique({
+      where: { id: userId },
+    });
+  };
   const findRefreshToken = async (userId: number, refreshToken: string) => {
     const tokenRecord = await prisma.refreshToken.findFirst({
       where: {
@@ -54,6 +57,7 @@ const authService = () => {
     saveRefreshToken,
     deleteRefreshToken,
     findRefreshToken,
+    findUserById,
   };
 };
 

--- a/backend/src/services/auth.sevice.ts
+++ b/backend/src/services/auth.sevice.ts
@@ -1,49 +1,60 @@
 import { prisma } from '../plugins/prisma';
 
-export async function saveUser(googleUser: any) {
-  const { email, name, picture } = googleUser;
+const authService = () => {
+  const saveUser = async (googleUser: any) => {
+    const { email, name, picture } = googleUser;
 
-  let user = await prisma.user.findUnique({ where: { email } });
+    let user = await prisma.user.findUnique({ where: { email } });
 
-  if (!user) {
-    user = await prisma.user.create({
+    if (!user) {
+      user = await prisma.user.create({
+        data: {
+          email,
+          nickname: name || email.split('@')[0],
+          profileImage: picture,
+          password: '',
+        },
+      });
+    }
+
+    return user;
+  };
+
+  const saveRefreshToken = async (userId: number, token: string) => {
+    return prisma.refreshToken.create({
       data: {
-        email,
-        nickname: name || email.split('@')[0],
-        profileImage: picture,
-        password: '',
+        userId,
+        token,
       },
     });
-  }
+  };
 
-  return user;
-}
+  const deleteRefreshToken = async (token: string) => {
+    return prisma.refreshToken.deleteMany({
+      where: { token },
+    });
+  };
 
-export async function saveRefreshToken(userId: number, token: string) {
-  return prisma.refreshToken.create({
-    data: {
+  const findRefreshToken = async (userId: number, refreshToken: string) => {
+    const tokenRecord = await prisma.refreshToken.findFirst({
+      where: {
+        userId,
+        token: refreshToken,
+      },
+    });
+
+    return {
       userId,
-      token,
-    },
-  });
-}
-
-export async function deleteRefreshToken(token: string) {
-  return prisma.refreshToken.deleteMany({
-    where: { token },
-  });
-}
-
-export async function findRefreshToken(userId: number, refreshToken: string) {
-  const tokenRecord = await prisma.refreshToken.findFirst({
-    where: {
-      userId,
-      token: refreshToken,
-    },
-  });
+      tokenRecord,
+    };
+  };
 
   return {
-    userId,
-    tokenRecord,
+    saveUser,
+    saveRefreshToken,
+    deleteRefreshToken,
+    findRefreshToken,
   };
-}
+};
+
+export default authService();

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -1,1 +1,2 @@
 export { default as authService } from './auth.sevice';
+export { default as twoFAService } from './2fa.service';

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -1,1 +1,1 @@
-export * from './auth.sevice';
+export { default as authService } from './auth.sevice';

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
 
 declare module 'fastify' {
   interface FastifyRequest {
-    user?: string | object;
+    user: TokenPayload;
   }
 }
 import { JwtPayload } from 'jsonwebtoken';


### PR DESCRIPTION
<!--- merge할 branch 확인해주세요 -->
<!--- PR 제목 수정해주세요 -->
<!--- ex) #이슈번호 [BE/FE] 작업 : 설명 -->

#️⃣Issue Number
-
<!--- 이슈 번호를 작성해주세요 -->
<!--- ex) #11 -->
- close #30 

📝Key Changes
-
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 2fa의 enable 을 켰을 경우, qrcode를 전송하여, 사용자로 하여금 인증앱에 등록하도록 하였습니다.
- 2fa가 켜져있을 시, 5분의 임시 토큰으로 인증하며, 2fa가 꺼져있다면 기존 로그인과 동일합니다.
- schema에서 refreshToken의 userId를 unique 값으로 설정하였습니다.
    - refreshToken이 기존에는 create 문에서 upsert 문으로 변경했기 때문입니다.
- 2fa가 켜져있는 상황에서 실수로 인증앱에서 지웠을 경우 구글이메일로 reset하는 로직을 추가했습니다.
- 저번 회의 때 이야기 나왔었던 구조를 레퍼런스 강의에 맞추어 수정하였습니다.
    - lib, handlers, services 전부 하나의 함수를 리턴합니다. 

#### 📸스크린샷 (선택)

<img width="675" alt="image" src="https://github.com/user-attachments/assets/009350ea-02be-44d1-8458-003860935a52" />

📣To Reviewers
-
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 로직이 추가되다 보니 새로 추가한 api가 굉장히 많습니다. 함께 당위성을 이야기 해봐야 할 것 같습니다.
- 2fa의 전체적인 흐름을 정리하고 프론트 분들과도 회의를 한번 진행해야 할 것 같습니다.
- 스키마와 타입박스를 2fa에도 추가하였습니다. 한번 확인 부탁드립니다.

✅ PR Checklist
- 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
